### PR TITLE
Fix trim-newlines vulneratibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiendanube/icons",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiendanube/icons",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "cheerio": "1.0.0-rc.12",
@@ -14,7 +14,7 @@
         "lodash.merge": "4.6.2",
         "path": "0.12.7",
         "svgo": "1.3.2",
-        "trim-newlines": "3.0.0",
+        "trim-newlines": "3.0.1",
         "yargs": "15.3.1"
       },
       "devDependencies": {
@@ -8180,9 +8180,9 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "engines": {
         "node": ">=8"
       }
@@ -15628,9 +15628,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-right": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/icons",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Nimbus Icons",
   "private": false,
   "main": "dist/index.umd.js",
@@ -50,7 +50,7 @@
     "lodash.merge": "4.6.2",
     "path": "0.12.7",
     "svgo": "1.3.2",
-    "trim-newlines": "3.0.0",
+    "trim-newlines": "3.0.1",
     "yargs": "15.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4970,10 +4970,10 @@
   dependencies:
     "punycode" "^2.1.0"
 
-"trim-newlines@3.0.0":
-  "integrity" "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
-  "resolved" "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz"
-  "version" "3.0.0"
+"trim-newlines@3.0.1":
+  "integrity" "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+  "resolved" "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz"
+  "version" "3.0.1"
 
 "trim-right@^1.0.1":
   "integrity" "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="


### PR DESCRIPTION
Este PR realiza una actualización de la dependencia trim-newlines, [arreglando un problema de utilización de recursos](https://github.com/advisories/GHSA-7p7h-4mm5-852v), abriendo la puerta a un potencial ataque.